### PR TITLE
fix(action): correct args splitting, output name, and add exclude input

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ jobs:
         uses: KacperMalachowski/image-detector-action@v1
         with:
           directory: "images"
-      - run: echo ${{ steps.images.outputs.image_urls
+      - run: echo "${{ steps.images.outputs.images }}"
 ```
 
 ### As a CLI Tool
@@ -80,20 +80,21 @@ go build -o image-detector ./cmd/image-detector
 #### Run
 
 ```sh
-./image-detector --path . --output report.txt
+./image-detector -d .
 ```
 
 ---
 
 ## Inputs
 
-| Name     | Description                       | Required | Default |
-|----------|-----------------------------------|:--------:|:-------:|
-| directory| Path to scan for images           |   No     |   `.`   |
+| Name      | Description                                                                                       | Required | Default                                              |
+|-----------|---------------------------------------------------------------------------------------------------|:--------:|:----------------------------------------------------:|
+| directory | Path to scan for images                                                                           |   No     | `.`                                                  |
+| exclude   | Comma-separated glob patterns to exclude. An empty string disables the defaults.                  |   No     | `**.git**,**.git/**,**node_modules**,**vendor**`     |
 
 ## Outputs
 
-- `image_urlst` — List of detected Docker image URLs.
+- `images` — JSON array of detected Docker image URLs.
 
 ---
 

--- a/action.yml
+++ b/action.yml
@@ -1,21 +1,31 @@
 name: docker-image-detector
 description: |
-  Find docker image urls in a files over the git repository and produce a list of then.
+  Find docker image URLs in files across a git repository and produce a list of them.
 inputs:
   directory:
     description: |
-      Directory to search for docker image urls.
-      Default is the current directory.
+      Directory to search for docker image URLs.
+      Defaults to the current directory.
     required: false
     default: '.'
-outputs:
-  image_urls:
+  exclude:
     description: |
-      List of docker image urls found in the files.
+      Comma-separated list of glob patterns to exclude from detection.
+      Defaults mirror the CLI's built-in exclusions; override only if you
+      know what you are doing — an empty string disables the defaults.
+    required: false
+    default: '**.git**,**.git/**,**node_modules**,**vendor**'
+outputs:
+  images:
+    description: |
+      List of docker image URLs found in the scanned files.
       The format is a JSON array of strings.
 
 runs:
   using: 'docker'
   image: docker://ghcr.io/kacpermalachowski/image-detector:v20250909-e91e7a3
   args:
-    - -d ${{ inputs.directory }}
+    - --check-directory
+    - ${{ inputs.directory }}
+    - --exclude
+    - ${{ inputs.exclude }}


### PR DESCRIPTION
## Summary

Fixes two bugs in `action.yml` that prevent the action from running correctly, plus several documentation errors. Adds a long-missing `exclude` input that maps to the existing CLI flag.

## Bugs fixed

### 1. `args` was passed as a single string instead of two array entries

Before:
```yaml
args:
  - -d ${{ inputs.directory }}
```

This passes the literal string `-d <directory>` as a single argv entry. Cobra/viper sees one positional arg, not a flag. The CLI never receives `-d`.

After:
```yaml
args:
  - --check-directory
  - ${{ inputs.directory }}
  - --exclude
  - ${{ inputs.exclude }}
```

### 2. Declared output name didn't match what the CLI writes

`cmd/root.go::setImagesOutput` does:
```go
githubactions.SetOutput("images", string(output))
```

But `action.yml` declared the output as `image_urls`. Callers reading `steps.<id>.outputs.image_urls` always got an empty string.

Renamed the output to `images` to match.

## New feature: `exclude` input

The CLI already supports `--exclude` (StringSlice). The action surface didn't expose it. Added the input with a default mirroring the viper defaults in `cmd/root.go`:

```
**.git**,**.git/**,**node_modules**,**vendor**
```

Behavior:
- Empty input string → defaults are disabled (matches viper's StringSlice semantics).
- Setting the input replaces the defaults entirely (no merging).

The default is duplicated between the action and the CLI source. That's a minor drift risk but keeps the contract visible at the action surface, which matters more here.

## README fixes

- Workflow example: closed unterminated `${{ ... }}` and updated the output name to `images`.
- CLI example: wrong flag `--path` → `-d` (the flag is registered as `check-directory`/`-d` in `cmd/root.go`). Dropped the nonexistent `--output report.txt`.
- Outputs section: typo `image_urlst` → `images`.
- Inputs table: documented the new `exclude` input.

## Out of scope

- The Go CLI uses `golang-set`'s `ToSlice()` to produce its output, which is **not deterministic** across runs. This causes noisy diffs in any consumer that commits the result. Worth fixing in a follow-up by sorting in `setImagesOutput`. Flagged but not addressed here to keep this PR focused on the action surface.
- Image reference (`docker://ghcr.io/kacpermalachowski/image-detector:v20250909-e91e7a3`) is unchanged. A future move to `malachowski-labs` org will be a separate PR.

## Testing

I haven't run an end-to-end test from a workflow. Would appreciate the maintainer running it once before un-drafting.