### PR TITLE
fix(ci): bump trivy-action to v0.36.0

### DIFF
--- a/.github/workflows/trivy.yml
+++ b/.github/workflows/trivy.yml
@@ -20,7 +20,7 @@ jobs:
         uses: actions/checkout@v5
 
       - name: Run Trivy in repo mode
-        uses: aquasecurity/trivy-action@0.33.1
+        uses: aquasecurity/trivy-action@v0.36.0
         with:
           scan-type: 'fs'
           ignore-unfixed: true


### PR DESCRIPTION
## Summary

The `trivy.yml` workflow has been failing due to **two compounding bugs**. This PR fixes both with a single one-line change.

### Bug 1: Action ref didn't exist

The workflow referenced `aquasecurity/trivy-action@0.33.1` (no `v` prefix). The actual upstream tag is `v0.33.1`. Every run failed at action resolution time:

```
Unable to resolve action `aquasecurity/trivy-action@0.33.1`, unable to find version `0.33.1`
```

### Bug 2: trivy-action v0.33.1's default trivy binary doesn't exist

After fixing the prefix, the action resolved but its install step still failed. trivy-action v0.33.1 hardcodes a default of trivy `v0.65.0` for the binary to install — but **that trivy release was never published**. There's a gap in the upstream timeline between trivy v0.26.0 and v0.69.2, and v0.65.0 falls into that gap. The install step exits with code 1 after godownloader can't find the asset.

## Fix

Bump trivy-action to the latest tagged release `v0.36.0`. Its default trivy binary version is `v0.70.0`, which **does** exist. This matches the action+binary combination the trivy-action maintainers test against.

## What I considered and rejected

| Approach | Why not |
|---|---|
| Just fix the `v` prefix → `v0.33.1` | Doesn't actually work — bug 2 still triggers. Confirmed empirically on a previous push to this branch. |
| Keep `v0.33.1` and pass `version: v0.71.0` as input | Workaround layered on top of a stale pin. Action and binary versions then drift independently. Brittle. |
| Pin `v0.36.0` to a full commit SHA | Would deviate from this repo's existing convention — `actions/checkout@v5`, `github/codeql-action/upload-sarif@v3` all use plain tags. Convention change is out of scope here. |

## Verification

CI on this PR will exercise the corrected ref. If trivy completes (success or finding-related failure) instead of either failing at resolution time or exit code 1 in the install step, the fix is correct.

## Context

Discovered while investigating CI failures on #51. Filed as a separate single-purpose PR so #51 can rebase on a green main.